### PR TITLE
Add config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ dist
 
 # Macos
 .DS_Store
+
+# Cyber Bot Config
+config.json

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const path = require("node:path");
 // Require the necessary discord.js classes
 const { Client, Collection, Events, GatewayIntentBits } = require("discord.js");
 
+// Load config
+require("./utilities/config.js");
+
 // Create a new client instance
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 

--- a/utilities/config.js
+++ b/utilities/config.js
@@ -1,0 +1,29 @@
+// Config file handling
+const fs = require("node:fs");
+
+const CONFIG_FILE = __dirname + "/../config.json";
+const DEFAULT_CONFIG = {};
+
+let config;
+
+try {
+  config = JSON.parse(fs.readFileSync(CONFIG_FILE));
+} catch (e) {
+  if (e.code === "ENOENT") {
+    console.log("Initializing config...");
+    fs.writeFileSync(
+      CONFIG_FILE,
+      JSON.stringify(DEFAULT_CONFIG, null, 4) + "\n"
+    );
+    config = DEFAULT_CONFIG;
+  } else if (e instanceof SyntaxError) {
+    const ERROR_MSG = "The config file has syntax errors, exiting!";
+    const SEPARATOR = "=".repeat(ERROR_MSG.length);
+    console.error(`${SEPARATOR}\n${ERROR_MSG}\n${SEPARATOR}\n`);
+    throw e;
+  } else {
+    throw e;
+  }
+}
+
+module.exports = config;


### PR DESCRIPTION
## API

To read from the config in a command script:
```js
let config = require("../utilities/config.js");
```

To specify a "template" for how the config will look like by default, edit the `DEFAULT_CONFIG` field in `utilities/config.js`:
```js
const DEFAULT_CONFIG = {
    "xpost": {
        "servers": {}
    }
}
```


